### PR TITLE
Fix: マイライブラリの検索フォームのバグの修正

### DIFF
--- a/app/javascript/pages/tracks/MyLibrary.vue
+++ b/app/javascript/pages/tracks/MyLibrary.vue
@@ -28,10 +28,9 @@
           type="text"
           filled
           dense
-          clearable
           label="Search"
-          clear-icon="mdi-close-thick"
-          @click:clear="clearSearch"
+          :append-icon="this.search != '' ? 'mdi-close-thick' : ''"
+          @click:append="clearSearch"
         >
           <template v-slot:prepend-inner>
             <v-icon>mdi-magnify</v-icon>
@@ -103,8 +102,7 @@ export default {
   methods: {
     ...mapActions("myLibrary", [
       "fetchTracks",
-      // "addTrack",
-      "deleteTrack",
+      "deleteTrack"
     ]),
 
     ...mapActions("historyTracks", [


### PR DESCRIPTION
## 概要

マイライブラリの検索フォームを一括削除すると値が`null`になり`toLowerCase`がエラーになって再度検索ができなくなってしまうため、`clearable`を使用せず自作メソッドで削除機能を実装

## 確認方法

マイライブラリの検索フォームに入力をして、バツ印を押して削除してから再度検索フォームに入力しても、正常に検索ができることをご確認ください。

## チェックリスト

- [ ] Rubocop のチェックをパスした
- [ ] システムテストをパスした

## コメント

ご確認よろしくお願い致します。