### PR TITLE
ヘッダーのレイアウト変更

### DIFF
--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -4,7 +4,6 @@
     color="black"
     height="80"
   >
-
     <v-toolbar-title
       style="cursor: pointer"
       @click="$router.push('/').catch(err => {})"
@@ -18,15 +17,6 @@
     <v-spacer />
 
     <template v-if="$vuetify.breakpoint.mdAndUp">
-      <v-btn
-        text
-        :to="{ name: 'Top' }"
-        class="mr-5"
-        exact
-      >
-        <v-icon>mdi-home</v-icon>
-        ホーム
-      </v-btn>
       <template v-if="authUser">
         <v-btn
           text
@@ -36,59 +26,34 @@
           <v-icon>mdi-magnify</v-icon>
           楽曲検索
         </v-btn>
-        <v-menu
-          offset-y
-          transition="scale-transition"
+
+        <v-btn
+          text
+          :to="{ name: 'MyLibrary' }"
+          exact
         >
-          <template v-slot:activator="{ on: menu, attrs }">
-            <v-tooltip bottom>
-              <template v-slot:activator="{ on: tooltip }">
-                <v-icon
-                  x-large
-                  v-bind="attrs"
-                  v-on="{ ...tooltip, ...menu }"
-                  class="mr-12 ml-8"
-                  id="user-menu"
-                >
-                  mdi-account
-                </v-icon>
-              </template>
-              <span>ユーザーメニュー</span>
-            </v-tooltip>
-          </template>
-          <v-list>
-            <v-list-item
-              :to="{ name: 'MyLibrary' }"
-              id="my-library"
-              exact
-            >
-              <v-list-item-title>
-                <v-icon>mdi-music-box-multiple</v-icon>
-                マイライブラリ
-              </v-list-item-title>
-            </v-list-item>
-            <v-list-item
-              :to="{ name: 'UserInformation' }"
-              id="user-information"
-              exact
-            >
-              <v-list-item-title>
-                <v-icon>mdi-account</v-icon>
-                ユーザー情報
-              </v-list-item-title>
-            </v-list-item>
-            <v-divider />
-            <v-list-item
-              @click="handleLogout"
-              id="logout"
-            >
-              <v-list-item-title class="error--text">
-                <v-icon color="error">mdi-logout</v-icon>
-                ログアウト
-              </v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
+          <v-icon>mdi-music-box-multiple</v-icon>
+          マイライブラリ
+        </v-btn>
+
+        <v-btn
+          text
+          :to="{ name: 'UserInformation' }"
+          exact
+        >
+          <v-icon>mdi-account</v-icon>
+          ユーザー情報
+        </v-btn>
+
+        <v-btn
+          text
+          @click="handleLogout"
+          exact
+          color="error"
+        >
+          <v-icon>mdi-logout</v-icon>
+          ログアウト
+        </v-btn>
       </template>
       <template v-else>
         <v-btn

--- a/spec/system/create_delete_tracks_spec.rb
+++ b/spec/system/create_delete_tracks_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "CreateDeleteTracks", type: :system do
         sleep 1
         expect(page).to have_content 'マイライブラリに追加しました'
         expect(find('#tracks-list')).to have_selector '#delete-icon'
-        find('#user-menu').click
         click_on 'マイライブラリ'
         expect(current_path).to eq '/mylibrary'
         expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_NAME']
@@ -37,7 +36,6 @@ RSpec.describe "CreateDeleteTracks", type: :system do
         sleep 1
         expect(page).to have_content 'マイライブラリから削除しました'
         expect(find('#tracks-list')).to have_selector '#create-icon'
-        find('#user-menu').click
         click_on 'マイライブラリ'
         expect(current_path).to eq '/mylibrary'
         expect(find('#tracks-list')).not_to have_content ENV['SEARCH_TRACK_NAME']

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe "Sessions", type: :system do
         sleep 3
         expect(page).to have_content 'ログインしました'
         expect(page).to have_content '楽曲検索'
-        find('#user-menu').click
         expect(page).to have_content 'マイライブラリ'
         expect(page).to have_content 'ユーザー情報'
         expect(page).to have_content 'ログアウト'
@@ -121,11 +120,10 @@ RSpec.describe "Sessions", type: :system do
         sleep 3
         expect(page).to have_content 'ログインしました'
         expect(page).to have_content '楽曲検索'
-        find('#user-menu').click
         expect(page).to have_content 'マイライブラリ'
         expect(page).to have_content 'ユーザー情報'
         expect(page).to have_content 'ログアウト'
-        find('#logout').click
+        click_on 'ログアウト'
         sleep 2
         expect(page).to have_content 'ログアウトしました'
         expect(current_path).to eq root_path

--- a/spec/system/user_edits_spec.rb
+++ b/spec/system/user_edits_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "UserEdits", type: :system do
     context "名前を変更する" do
       it "更新に成功し、フラッシュメッセージが表示され、表示されている名前が変更後のものになっている" do
         visit root_path
-        find('#user-menu').click
-        find('#user-information').click
+        click_on 'ユーザー情報'
         expect(current_path).to eq '/user'
         click_on 'ユーザー情報編集'
         expect(page).to have_field '名前', with: user.name
@@ -26,8 +25,7 @@ RSpec.describe "UserEdits", type: :system do
   context "メールアドレスを変更する" do
     it "更新に成功し、フラッシュメッセージが表示され、表示されているメールアドレスが変更後のものになっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -43,8 +41,7 @@ RSpec.describe "UserEdits", type: :system do
   context "パスワードを変更する" do
     it "更新に成功し、フラッシュメッセージが表示される" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -60,8 +57,7 @@ RSpec.describe "UserEdits", type: :system do
   context "名前を未入力にする" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -75,8 +71,7 @@ RSpec.describe "UserEdits", type: :system do
   context "名前を11文字で入力にする" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -90,8 +85,7 @@ RSpec.describe "UserEdits", type: :system do
   context "メールアドレスを未入力にする" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -105,8 +99,7 @@ RSpec.describe "UserEdits", type: :system do
   context "メールアドレスがメールアドレスの形式で入力されていない" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -122,8 +115,7 @@ RSpec.describe "UserEdits", type: :system do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       existed_user = create(:user)
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -138,8 +130,7 @@ RSpec.describe "UserEdits", type: :system do
   context "一度メールアドレスのフィールドを空にしてから自分のメールアドレスを入力する" do
     it "登録済みのエラーが出ない" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -154,8 +145,7 @@ RSpec.describe "UserEdits", type: :system do
   context "パスワードとパスワード確認を2文字で入力する" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name
@@ -171,8 +161,7 @@ RSpec.describe "UserEdits", type: :system do
   context "パスワードとパスワード確認が一致していない" do
     it "エラーメッセージが表示され、更新ボタンが押せなくなっている" do
       visit root_path
-      find('#user-menu').click
-      find('#user-information').click
+      click_on 'ユーザー情報'
       expect(current_path).to eq '/user'
       click_on 'ユーザー情報編集'
       expect(page).to have_field '名前', with: user.name


### PR DESCRIPTION
## 概要

- ヘッダーメニューのホームへのボタンを削除
- ユーザーアカウントマークのメニューボタンを削除し、全てそのまま並べた

## 確認方法

1. ヘッダーメニューにホームへのリンクボタンがなくなっていること
2. ログイン後のユーザーアカウントマークのメニューボタンがなくなっていて、全てのボタンがそのまま並べられていること
---
以上をご確認ください。

## チェックリスト

- [ ] Rubocop のチェックをパスした
- [ ] システムテストをパスした

## コメント

ご確認よろしくお願い致します。